### PR TITLE
Added performance statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
     <title>Hello World!</title>
     <!-- https://electronjs.org/docs/tutorial/security#csp-meta-tag -->
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
+    <style>
+      .performanceStatistics {
+        margin-top: 5rem;
+        margin-bottom: 5rem;
+        border-collapse: collapse;
+      }
+      .performanceStatistics tr,td {
+        border-bottom: 1px solid rgb(165, 165, 165);
+        border-top: 1px solid rgb(165, 165, 165);
+        padding: .5rem;
+      }
+    </style>
   </head>
   <body>
     <h1>Hello from OBS Studio Node!</h1>
@@ -16,6 +28,32 @@
     <span id="rec-timer">0:00:00.0</span>
 
     <button title="Open folder with videos" onclick="openFolder()">📂</button>
+
+    <table class="performanceStatistics">
+      <tr>
+        <td>CPU</td>
+        <td>
+          <meter id="cpuMeter" value="0" min="0" optimum="50" low="65" high="80" max="100"></meter>
+          <span id="cpu">Loading...</span>
+        </td>
+      </tr>
+      <tr>
+        <td>Dropped frames</td>
+        <td id="numberDroppedFrames">Loading...</td>
+      </tr>
+      <tr>
+        <td>Dropped frames</td>
+        <td id="percentageDroppedFrames">Loading...</td>
+      </tr>
+      <tr>
+        <td>Bandwidth</td>
+        <td id="bandwidth">Loading...</td>
+      </tr>
+      <tr>
+        <td>Framerate</td>
+        <td id="frameRate">Loading...</td>
+      </tr>
+    </table>
 
     <pre>
     We are using node <script>document.write(process.versions.node)</script>,

--- a/index.js
+++ b/index.js
@@ -5,11 +5,6 @@ const obsRecorder = require('./obsRecorder');
 
 // Replace with ipcMain.handle when obs-studio-node will be ready to work on recent versions of Electron.
 // See https://github.com/stream-labs/obs-studio-node/issues/605
-ipcMain.on('recording-init', (event) => {
-  obsRecorder.initialize();
-  event.returnValue = true;
-});
-
 ipcMain.on('recording-start', (event) => {
   obsRecorder.start();
   event.returnValue = { recording: true };
@@ -32,36 +27,41 @@ function createWindow () {
     webPreferences: {
       nodeIntegration: true
     }
-  })
+  });
+
+  ipcMain.on('recording-init', (event) => {
+    obsRecorder.initialize(win.webContents);
+    event.returnValue = true;
+  });
 
   // and load the index.html of the app.
-  win.loadFile('index.html')
+  win.loadFile('index.html');
 
   // Open the DevTools.
-  win.webContents.openDevTools()
+  win.webContents.openDevTools();
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(createWindow);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow()
+    createWindow();
   }
-})
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/obsRecorder.js
+++ b/obsRecorder.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { Subject } = require('rxjs');
 const { first } = require('rxjs/operators');
-const { ipcMain } = require('electron');
 
 const osn = require("obs-studio-node");
 

--- a/obsRecorder.js
+++ b/obsRecorder.js
@@ -1,22 +1,27 @@
 const path = require('path');
 const { Subject } = require('rxjs');
 const { first } = require('rxjs/operators');
+const { ipcMain } = require('electron');
 
 const osn = require("obs-studio-node");
 
 let obsInitialized = false;
 
 // Init the library, launch OBS Studio instance, configure it, set up sources and scene
-function initialize() {
+function initialize(webContents) {
   if (obsInitialized) {
     console.warn("OBS is already initialized, skipping initialization.");
-    return
+    return;
   }
 
   initOBS();
   configureOBS();
   setupSources();
   obsInitialized = true;
+
+  setInterval(() => {
+    webContents.send("performanceStatistics", osn.NodeObs.OBS_API_getPerformanceStatistics());
+  }, 1000);
 }
 
 function initOBS() {
@@ -56,17 +61,17 @@ function configureOBS() {
   const availableEncoders = getAvailableValues('Output', 'Recording', 'RecEncoder');
   setSetting('Output', 'RecEncoder', availableEncoders.slice(-1)[0] || 'x264');
   setSetting('Output', 'FilePath', path.join(__dirname, 'videos'));
-  setSetting('Output', 'RecFormat', 'mkv')
-  setSetting('Output', 'VBitrate', 10000) // 10 Mbps
-  setSetting('Video', 'FPSCommon', 60)
+  setSetting('Output', 'RecFormat', 'mkv');
+  setSetting('Output', 'VBitrate', 10000); // 10 Mbps
+  setSetting('Video', 'FPSCommon', 60);
 
   console.debug('OBS Configured');
 }
 
 function setupSources() {
-  const videoSource = osn.InputFactory.create('monitor_capture', 'desktop-video')
-  const audioSource = osn.InputFactory.create('wasapi_output_capture', 'desktop-audio')
-  const micSource = osn.InputFactory.create('wasapi_input_capture', 'mic-audio')
+  const videoSource = osn.InputFactory.create('monitor_capture', 'desktop-video');
+  const audioSource = osn.InputFactory.create('wasapi_output_capture', 'desktop-audio');
+  const micSource = osn.InputFactory.create('wasapi_input_capture', 'mic-audio');
 
   // Get information about prinary display
   const { screen } = require('electron');
@@ -91,13 +96,13 @@ function setupSources() {
 
   // A scene is necessary here to properly scale captured screen size to output video size
   const scene = osn.SceneFactory.create('test-scene');
-  const sceneItem = scene.add(videoSource)
-  sceneItem.scale = { x: 1.0/ videoScaleFactor, y: 1.0 / videoScaleFactor }
+  const sceneItem = scene.add(videoSource);
+  sceneItem.scale = { x: 1.0/ videoScaleFactor, y: 1.0 / videoScaleFactor };
 
   // Tell recorder to use this source (I'm not sure if this is the correct way to use the first argument `channel`)
-  osn.Global.setOutputSource(1, scene)
-  osn.Global.setOutputSource(2, audioSource)
-  osn.Global.setOutputSource(3, micSource)
+  osn.Global.setOutputSource(1, scene);
+  osn.Global.setOutputSource(2, audioSource);
+  osn.Global.setOutputSource(3, micSource);
 }
 
 async function start() {

--- a/renderer.js
+++ b/renderer.js
@@ -6,6 +6,9 @@ function initOBS() {
   // See https://github.com/stream-labs/obs-studio-node/issues/605
   const result = ipcRenderer.sendSync('recording-init');
   console.debug("initOBS result:", result);
+  if (result) {
+    ipcRenderer.on("performanceStatistics", (_event, data) => onPerformanceStatistics(data));
+  }
 }
 
 function startRecording() {
@@ -66,6 +69,15 @@ function updateTimer() {
 
 function openFolder() {
   shell.openItem(path.join(__dirname, 'videos'));
+}
+
+function onPerformanceStatistics(data) {
+  document.querySelector(".performanceStatistics #cpu").innerText = `${data.CPU} %`;
+  document.querySelector(".performanceStatistics #cpuMeter").value = data.CPU;
+  document.querySelector(".performanceStatistics #numberDroppedFrames").innerText = data.numberDroppedFrames;
+  document.querySelector(".performanceStatistics #percentageDroppedFrames").innerText = `${data.percentageDroppedFrames} %`;
+  document.querySelector(".performanceStatistics #bandwidth").innerText = data.bandwidth;
+  document.querySelector(".performanceStatistics #frameRate").innerText = `${Math.round(data.frameRate)} fps`;
 }
 
 try {


### PR DESCRIPTION
Hi,
I added a performance statistics feature. It updates every second and looks like this:
![grafik](https://user-images.githubusercontent.com/18656830/79373392-36839580-7ef2-11ea-8535-726f40d54ae5.png)
I also added some semicolons for a consistent code style.

In case you want to this repo to just show the basic usage without any additional features, I can also create a new repo and put all my experiments there (I'm working on projectors / preview / etc. )