### PR TITLE
added virtual camera controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ You find the generated installer in the dist folder.
 
 See [this topic](https://obsproject.com/forum/threads/laptop-black-screen-when-capturing-read-here-first.5965/) on how to solve black screen on laptops with two video cards.
 
+### Virtual Camera
+After clicking the `Install Plugin` and the `Start Virtual Camera` button, a new webcam will be available for you to use in any other program (like Zoom or Microsoft Teams).
+
+It will output exactly the same content which is displayed in the preview, in this case, it's the screen recording and maybe your webcam.
+
+However, the webcam shows up as `Streamlabs OBS Virtual Camera` and we can't change the name for now (see [#44](https://github.com/Envek/obs-studio-node-example/issues/44)).
+
 ## Code of interest
 
 Most of the interesting things are located in [`obsRecorder.js`](./obsRecorder.js). Some snippets are taken verbatim from [obs-studio-node] tests and [streamlabs-obs] source code, but some are results of experiments.

--- a/index.html
+++ b/index.html
@@ -19,18 +19,38 @@
         border-top: 1px solid rgb(165, 165, 165);
         padding: .5rem;
       }
+      .d-block {
+        display: block;
+      }
+      .border {
+        border: 1px solid grey;
+        border-radius: 1rem;
+        padding: 0.5rem;
+        margin-bottom: 1rem;
+      }
     </style>
   </head>
   <body>
     <h1>Hello from OBS Studio Node!</h1>
 
-    <button id="rec-button" onclick="switchRecording()">
-      ⏳ Initializing, please wait...
-    </button>
-
-    <span id="rec-timer">0:00:00.0</span>
-
-    <button title="Open folder with videos" onclick="openFolder()">📂</button>
+    <div class="d-block border">
+      <b>Recording:</b><br>
+      <button id="rec-button" onclick="switchRecording()">
+        ⏳ Initializing, please wait...
+      </button>
+      
+      <span id="rec-timer">0:00:00.0</span>
+      
+      <button title="Open folder with videos" onclick="openFolder()">📂</button>
+    </div>
+    <div class="d-block border">
+      <b>Virtual Camera:</b><br>
+      <button id="install-virtual-cam-plugin-button" onclick="installVirtualCamPlugin()">Install Plugin</button>
+      <button id="uninstall-virtual-cam-plugin-button" onclick="uninstallVirtualCamPlugin()">Uninstall Plugin</button>
+      <button id="start-virtual-cam-button" onclick="startVirtualCam()">Start Virtual Camera</button>
+      <button id="stop-virtual-cam-button" onclick="stopVirtualCam()">Stop Virtual Camera</button>
+      <span id="virtual-cam-plugin-status">...</span>
+    </div>
 
     <div id="preview">
       Initializing...

--- a/index.js
+++ b/index.js
@@ -13,6 +13,22 @@ ipcMain.handle('recording-stop', (event) => {
   return { recording: false };
 });
 
+ipcMain.handle('isVirtualCamPluginInstalled', (event) => {
+  return obsRecorder.isVirtualCamPluginInstalled();
+});
+ipcMain.handle('startVirtualCam', (event) => {
+  return obsRecorder.startVirtualCam();
+});
+ipcMain.handle('stopVirtualCam', (event) => {
+  return obsRecorder.stopVirtualCam();
+});
+ipcMain.handle('installVirtualCamPlugin', (event) => {
+  return obsRecorder.installVirtualCamPlugin();
+});
+ipcMain.handle('uninstallVirtualCamPlugin', (event) => {
+  return obsRecorder.uninstallVirtualCamPlugin();
+});
+
 app.on('will-quit', obsRecorder.shutdown);
 
 function createWindow () {

--- a/obsRecorder.js
+++ b/obsRecorder.js
@@ -85,6 +85,32 @@ function configureOBS() {
   console.debug('OBS Configured');
 }
 
+function isVirtualCamPluginInstalled() {
+  return osn.NodeObs.OBS_service_isVirtualCamPluginInstalled();
+}
+
+function installVirtualCamPlugin() {
+  osn.NodeObs.OBS_service_installVirtualCamPlugin();
+  return osn.NodeObs.OBS_service_isVirtualCamPluginInstalled();
+}
+
+function uninstallVirtualCamPlugin() {
+  osn.NodeObs.OBS_service_uninstallVirtualCamPlugin();
+  return !osn.NodeObs.OBS_service_isVirtualCamPluginInstalled();
+}
+
+function startVirtualCam() {
+  osn.NodeObs.OBS_service_createVirtualWebcam("obs-studio-node-example-cam");
+  osn.NodeObs.OBS_service_startVirtualWebcam();
+}
+
+function stopVirtualCam() {
+  osn.NodeObs.OBS_service_stopVirtualWebcam();
+  osn.NodeObs.OBS_service_removeVirtualWebcam();
+}
+
+
+
 // Get information about prinary display
 function displayInfo() {
   const { screen } = require('electron');
@@ -414,6 +440,11 @@ function busySleep(sleepDuration) {
 
 module.exports.initialize = initialize;
 module.exports.start = start;
+module.exports.isVirtualCamPluginInstalled = isVirtualCamPluginInstalled;
+module.exports.installVirtualCamPlugin = installVirtualCamPlugin;
+module.exports.uninstallVirtualCamPlugin = uninstallVirtualCamPlugin;
+module.exports.startVirtualCam = startVirtualCam;
+module.exports.stopVirtualCam = stopVirtualCam;
 module.exports.stop = stop;
 module.exports.shutdown = shutdown;
 module.exports.setupPreview = setupPreview;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "GPL-2.0",  
   "dependencies": {
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/osn-0.10.10-release-win64.tar.gz",
+    "obs-studio-node": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.15.6-release-win64.tar.gz",
     "rxjs": "^6.6.3",
     "uuid": "^8.3.0"
   },

--- a/renderer.js
+++ b/renderer.js
@@ -22,6 +22,7 @@ async function stopRecording() {
 }
 
 let recording = false;
+let virtualCamRunning = false;
 let recordingStartedAt = null;
 let timer = null;
 
@@ -31,10 +32,10 @@ async function switchRecording() {
   } else {
     recording = (await startRecording()).recording;
   }
-  updateUI();
+  updateRecordingUI();
 }
 
-function updateUI() {
+function updateRecordingUI() {
   const button = document.getElementById('rec-button');
   button.disabled = false;
   if (recording) {
@@ -44,6 +45,51 @@ function updateUI() {
     button.innerText = '⏺️ Start recording'
     stopTimer();
   }
+}
+
+async function updateVirtualCamUI() {
+  if (await ipcRenderer.invoke('isVirtualCamPluginInstalled')) {
+    document.querySelector("#install-virtual-cam-plugin-button").style.display = "none";
+    if (virtualCamRunning) {
+      document.querySelector("#virtual-cam-plugin-status").innerText = "Running";
+      document.querySelector("#stop-virtual-cam-button").style.display = "";
+      document.querySelector("#start-virtual-cam-button").style.display = "none";
+      document.querySelector("#uninstall-virtual-cam-plugin-button").style.display = "none";
+    } else {
+      document.querySelector("#virtual-cam-plugin-status").innerText = "Plugin installed";
+      document.querySelector("#stop-virtual-cam-button").style.display = "none";
+      document.querySelector("#start-virtual-cam-button").style.display = "";
+      document.querySelector("#uninstall-virtual-cam-plugin-button").style.display = "";
+    }
+  } else {
+    document.querySelector("#virtual-cam-plugin-status").innerText = "Plugin not installed";
+    document.querySelector("#install-virtual-cam-plugin-button").style.display = "";
+    document.querySelector("#uninstall-virtual-cam-plugin-button").style.display = "none";
+    document.querySelector("#start-virtual-cam-button").style.display = "none";
+    document.querySelector("#stop-virtual-cam-button").style.display = "none";
+  }
+}
+
+async function uninstallVirtualCamPlugin() {
+  await ipcRenderer.invoke('uninstallVirtualCamPlugin');
+  updateVirtualCamUI();
+}
+
+async function installVirtualCamPlugin() {
+  await ipcRenderer.invoke('installVirtualCamPlugin');
+  updateVirtualCamUI();
+}
+
+async function startVirtualCam() {
+  await ipcRenderer.invoke('startVirtualCam');
+  virtualCamRunning = true;
+  updateVirtualCamUI();
+}
+
+async function stopVirtualCam() {
+  await ipcRenderer.invoke('stopVirtualCam');
+  virtualCamRunning = false;
+  updateVirtualCamUI();
 }
 
 function startTimer() {
@@ -101,7 +147,8 @@ ro.observe(document.querySelector("#preview"));
 try {
   initOBS();
   setupPreview();
-  updateUI();
+  updateRecordingUI();
+  updateVirtualCamUI();
 } catch (err) {
   console.log(err)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,9 +1305,9 @@ object-keys@^1.0.12:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/osn-0.10.10-release-win64.tar.gz":
-  version "0.10.10"
-  resolved "https://obsstudionodes3.streamlabs.com/osn-0.10.10-release-win64.tar.gz#0306ea8427827d579f5ae471ebab01a6d9d80598"
+"obs-studio-node@https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.15.6-release-win64.tar.gz":
+  version "0.15.6"
+  resolved "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.15.6-release-win64.tar.gz#dc8643c6ff0539d0df39a8293c959d0dcd038979"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Hi,
while recently digging through Streamlabs OBS's code, I found some methods for controlling the virtual camera plugin. It is quite easy to use.
This PR adds control buttons for installing the plugin, starting and stopping the camera as well as uninstalling it.
![grafik](https://user-images.githubusercontent.com/18656830/115208274-ac6d9e80-a0fc-11eb-9188-de95b818c753.png)
